### PR TITLE
Fix: Enable scaffolding of controllers w/ EF on modern Visual Studio

### DIFF
--- a/P7CreateRestApi/.gitignore
+++ b/P7CreateRestApi/.gitignore
@@ -1,15 +1,6 @@
-.DS_Store
-node_modules
-/dist
-
 # local env files
 .env.local
 .env.*.local
-
-# Log files
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
 
 # Editor directories and files
 .idea
@@ -18,6 +9,7 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+*.csproj.user
 
 /bin/**
 /obj/**

--- a/P7CreateRestApi/P7CreateRestApi.csproj
+++ b/P7CreateRestApi/P7CreateRestApi.csproj
@@ -1,19 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.16" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.16" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.16">
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/P7CreateRestApi/P7CreateRestApi.csproj.user
+++ b/P7CreateRestApi/P7CreateRestApi.csproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ActiveDebugProfile>P7CreateRestApi</ActiveDebugProfile>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
Most [Project 1455](https://openclassrooms.com/fr/paths/882/projects/1455)'s user stories talk about creating auto-generated code for entities management (see [US #1 for Bid entity](https://user.oc-static.com/upload/2024/06/13/1718291679881_16881113485142_image4.jpeg)). That strongly suggest the usage of Visual Studio's code-scaffolding tool (or Copilot?).

On Visual Studio Community v17.14.7, creating API controllers using Entity Framework would fail immediately without much explantations. It took 30 minutes to my mentor and I to figure out that upgrading dependencies and target framework solved the issue.

I take this PR as an opportunity to also un-track `P7CreateRestApi/P7CreateRestApi.csproj.user` and cleanup project's .gitignore a little bit.